### PR TITLE
PXC-2935: Assertion `server_state_.rollback_mode() == wsrep::server_s…

### DIFF
--- a/src/client_state.cpp
+++ b/src/client_state.cpp
@@ -116,8 +116,6 @@ int wsrep::client_state::before_command()
     {
         if (transaction_.state() == wsrep::transaction::s_must_abort)
         {
-            assert(server_state_.rollback_mode() ==
-                   wsrep::server_state::rm_async);
             override_error(wsrep::e_deadlock_error);
             lock.unlock();
             client_service_.bf_rollback();

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -921,6 +921,9 @@ bool wsrep::transaction::bf_abort(
             server_service_.background_rollback(client_state_);
         }
     }
+
+    client_service_.debug_sync("wsrep_after_bf_abort");
+
     return ret;
 }
 


### PR DESCRIPTION
…tate::rm_async' failed

https://jira.percona.com/browse/PXC-2935

Problem:
This problem occurred only if server was started with option --thread_handling=pool-of-threads.
1. Connection 1: start explicit transaction, execute 1st statement that acquires MDL lock
2. Connection 1: Execute 2nd statement. In threadpool_common.cc thread_attach() we wait for potential transaction that is being rolled back by background_rollbacker to finish. After this we acquire thread ownership and client_state's state is shifted to s_exec.
3. Connection 2: Just after acquiring ownership of the thread and moving state to s_exec by Connection 1 execute another query that conflicts with the MDL lock taken by Connection 1. This causes BF eviction of Connection 1 transaction, but as it is in s_exec state, rollback is not requested to be done by background_rollbacker. Transaction state is shifted to s_must_abort and is expected to be aborted in before_command() call.
4. Connection 1: the flow moves on and gets to before_command(). Transaction is in s_must_abort state and we hit the control path with assert that is wrong.

Solution:
Removed wrong assert.
Added MTR test.