### PR TITLE
Avoid concurrent rollback from rollbacker and rollback fragment

### DIFF
--- a/include/wsrep/compiler.hpp
+++ b/include/wsrep/compiler.hpp
@@ -20,7 +20,10 @@
 
 /** @file compiler.hpp
  *
- * Compiler specific options.
+ * Compiler specific macro definitions.
+ *
+ * WSREP_WARN_UNUSED_RESULT - Mark function or methods so that a warning is
+ *                            raised if its return value is unused.
  */
 
 #define WSREP_UNUSED __attribute__((unused))
@@ -29,3 +32,6 @@
 #else
 #define WSREP_OVERRIDE
 #endif // __cplusplus >= 201103L
+
+/* Fetched from https://github.com/codership/wsrep-lib/pull/123/ */
+#define WSREP_WARN_UNUSED_RESULT __attribute__((warn_unused_result))

--- a/include/wsrep/server_state.hpp
+++ b/include/wsrep/server_state.hpp
@@ -248,8 +248,20 @@ namespace wsrep
             const wsrep::transaction_id&,
             wsrep::high_priority_service*);
 
-        void stop_streaming_applier(
-            const wsrep::id&, const wsrep::transaction_id&);
+        /**
+         * Stop the streaming applier matching server and transaction ids
+         *
+         * If a corresponding streaming applier is found, it is stopped,
+         * and returned to the caller.
+         *
+         * @return pointer to the stopped streaming applier
+         *         nullptr if the streaming applier was already stopped
+         */
+        WSREP_WARN_UNUSED_RESULT
+        wsrep::high_priority_service* stop_streaming_applier(
+            const wsrep::id&,
+            const wsrep::transaction_id&);
+
         /**
          * Return reference to streaming applier.
          */

--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -74,8 +74,14 @@ discard_streaming_applier(wsrep::server_state& server_state,
                           wsrep::high_priority_service* streaming_applier,
                           const wsrep::ws_meta& ws_meta)
 {
-    server_state.stop_streaming_applier(
-        ws_meta.server_id(), ws_meta.transaction_id());
+    if (!server_state.stop_streaming_applier(
+            ws_meta.server_id(), ws_meta.transaction_id()))
+    {
+        wsrep::log_warning() << "Failed to stop streaming applier for "
+                             << ws_meta.server_id() << ":"
+                             << ws_meta.transaction_id();
+        assert(0);
+    }
     server_state.server_service().release_high_priority_service(
         streaming_applier);
     high_priority_service.store_globals();
@@ -234,9 +240,9 @@ static int rollback_fragment(wsrep::server_state& server_state,
 
     if (!ret)
     {
-        discard_streaming_applier(server_state, high_priority_service,
-                                  streaming_applier, ws_meta);
-
+        server_state.server_service().release_high_priority_service(
+            streaming_applier);
+        high_priority_service.store_globals();
         if (adopt_error == 0)
         {
           ret = high_priority_service.remove_fragments(ws_meta);
@@ -289,23 +295,27 @@ static int apply_write_set(wsrep::server_state& server_state,
         else
         {
             wsrep::high_priority_service* sa(
-                server_state.find_streaming_applier(
+                server_state.stop_streaming_applier(
                     ws_meta.server_id(), ws_meta.transaction_id()));
             if (sa == 0)
             {
-                // It is a known limitation that galera provider
-                // cannot always determine if certification test
-                // for interrupted transaction will pass or fail
-                // (see comments in transaction::certify_fragment()).
-                // As a consequence, unnecessary rollback fragments
-                // may be delivered here. The message below has
-                // been intentionally turned into a debug message,
-                // rather than warning.
-                 WSREP_LOG_DEBUG(wsrep::log::debug_log_level(),
-                                 wsrep::log::debug_level_server_state,
-                                 "Could not find applier context for "
-                                 << ws_meta.server_id()
-                                 << ": " << ws_meta.transaction_id());
+                // We might end up here for two reasons:
+                // 1) The SR transaction was BF aborted by TOI, and the
+                //    corresponding streaming applier has already been
+                //    stopped in transaction::bf_abort().
+                // 2) It is a known limitation that galera provider
+                //    cannot always determine if certification test
+                //    for interrupted transaction will pass or fail
+                //    (see comments in transaction::certify_fragment()).
+                //    As a consequence, unnecessary rollback fragments
+                //    may be delivered here.
+                // The message below has been intentionally turned into
+                // a debug message, rather than warning.
+                WSREP_LOG_DEBUG(wsrep::log::debug_log_level(),
+                                wsrep::log::debug_level_server_state,
+                                "Could not find applier context for "
+                                << ws_meta.server_id()
+                                << ": " << ws_meta.transaction_id());
                 ret = high_priority_service.log_dummy_write_set(
                     ws_handle, ws_meta, no_error);
             }
@@ -1239,24 +1249,20 @@ void wsrep::server_state::start_streaming_applier(
     }
 }
 
-void wsrep::server_state::stop_streaming_applier(
+wsrep::high_priority_service* wsrep::server_state::stop_streaming_applier(
     const wsrep::id& server_id,
     const wsrep::transaction_id& transaction_id)
 {
+    wsrep::high_priority_service* sa(0);
     wsrep::unique_lock<wsrep::mutex> lock(mutex_);
     streaming_appliers_map::iterator i(
         streaming_appliers_.find(std::make_pair(server_id, transaction_id)));
-    assert(i != streaming_appliers_.end());
-    if (i == streaming_appliers_.end())
-    {
-        wsrep::log_warning() << "Could not find streaming applier for "
-                             << server_id << ":" << transaction_id;
-    }
-    else
-    {
+    if (i != streaming_appliers_.end()) {
+        sa = i->second;
         streaming_appliers_.erase(i);
         cond_.notify_all();
     }
+    return sa;
 }
 
 wsrep::high_priority_service* wsrep::server_state::find_streaming_applier(

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -854,8 +854,6 @@ bool wsrep::transaction::bf_abort(
                                 "Seqno " << bf_seqno
                                 << " succesfully BF aborted " << id_
                                 << " victim_seqno " << victim_seqno);
-                bf_abort_state_ = state_at_enter;
-                state(lock, s_must_abort);
                 ret = true;
                 break;
             default:
@@ -880,7 +878,26 @@ bool wsrep::transaction::bf_abort(
 
     if (ret)
     {
+        if (is_streaming() &&
+            client_state_.mode() == wsrep::client_state::m_high_priority)
+        {
+            lock.unlock();
+            if (!client_state_.server_state().stop_streaming_applier(
+                    server_id_, id_))
+            {
+                // Streaming applier was already stopped, this happens
+                // if a rollback fragment has already been delivered.
+                // See rollback fragment processing in server_state.
+                lock.lock();
+                return false;
+            }
+            lock.lock();
+        }
+
+        bf_abort_state_ = state_at_enter;
         bf_abort_client_state_ = client_state_.state();
+        state(lock, s_must_abort);
+
         // If the transaction is in executing state, we must initiate
         // streaming rollback to ensure that the rollback fragment gets
         // replicated before the victim starts to roll back and release locks.
@@ -903,20 +920,11 @@ bool wsrep::transaction::bf_abort(
         {
             // We need to change the state to aborting under the
             // lock protection to avoid a race between client thread,
-            // otherwise it could happend that the client gains control
+            // otherwise it could happen that the client gains control
             // between releasing the lock and before background
             // rollbacker gets control.
             state(lock, wsrep::transaction::s_aborting);
             client_state_.set_rollbacker_active(true);
-
-            if (client_state_.mode() == wsrep::client_state::m_high_priority)
-            {
-                lock.unlock();
-                client_state_.server_state().stop_streaming_applier(
-                    server_id_, id_);
-                lock.lock();
-            }
-
             lock.unlock();
             server_service_.background_rollback(client_state_);
         }
@@ -1604,7 +1612,7 @@ void wsrep::transaction::debug_log_state(
         << ", mode: " << wsrep::to_c_string(client_state_.mode())
         << "\n    trx_id: " << int64_t(id_.get())
         << ", seqno: " << ws_meta_.seqno().get()
-        << ", flags: " << flags()
+        << ", flags: " << flags() << " (" << flags_to_string(flags()) << ")"
         << "\n"
         << "    state: " << wsrep::to_c_string(state_)
         << ", bfa_state: " << wsrep::to_c_string(bf_abort_state_)

--- a/test/transaction_test.cpp
+++ b/test/transaction_test.cpp
@@ -1134,7 +1134,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_row_streaming_rollback,
     BOOST_REQUIRE(hps);
     hps->rollback(wsrep::ws_handle(), wsrep::ws_meta());
     hps->after_apply();
-    sc.stop_streaming_applier(sc.id(), wsrep::transaction_id(1));
+    BOOST_REQUIRE(sc.stop_streaming_applier(sc.id(), wsrep::transaction_id(1)));
     server_service.release_high_priority_service(hps);
 }
 
@@ -1178,7 +1178,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_row_streaming_cert_fail_non_commit,
     BOOST_REQUIRE(hps);
     hps->rollback(wsrep::ws_handle(), wsrep::ws_meta());
     hps->after_apply();
-    sc.stop_streaming_applier(sc.id(), wsrep::transaction_id(1));
+    BOOST_REQUIRE(sc.stop_streaming_applier(sc.id(), wsrep::transaction_id(1)));
     server_service.release_high_priority_service(hps);
 }
 
@@ -1209,7 +1209,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_row_streaming_cert_fail_commit,
     BOOST_REQUIRE(hps);
     hps->rollback(wsrep::ws_handle(), wsrep::ws_meta());
     hps->after_apply();
-    sc.stop_streaming_applier(sc.id(), wsrep::transaction_id(1));
+    BOOST_REQUIRE(sc.stop_streaming_applier(sc.id(), wsrep::transaction_id(1)));
     server_service.release_high_priority_service(hps);
 }
 
@@ -1366,7 +1366,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_statement_streaming_cert_fail,
     BOOST_REQUIRE(hps);
     hps->rollback(wsrep::ws_handle(), wsrep::ws_meta());
     hps->after_apply();
-    sc.stop_streaming_applier(sc.id(), wsrep::transaction_id(1));
+    BOOST_REQUIRE(sc.stop_streaming_applier(sc.id(), wsrep::transaction_id(1)));
     server_service.release_high_priority_service(hps);
 }
 


### PR DESCRIPTION
PXC-2934: Assertion `owning_thread_id_ == wsrep::this_thread::get_id()' failed.

This patch avoids the situation where rollbacker is fired and
a rollback fragment attempt to rollback the same transaction
concurrently. This happens when a high priority streaming transaction
is BF aborted by TOI, and at the same time the transaction managed to
replicate one more fragment which fails certification. Failed
certification results in rollback fragment, which may be delivered
and processes before the streaming applier is stopped by in bf_abort().
The fix consists in changing rollback fragment processing so that
it stops the corresponding streaming applier right away.
Should a rollback fragment and BF abort happen concurrently, we now
expect that only one of the two manages stop the affected streaming
applier. So that the transaction is either rolled back by rollback
fragment or rollbacker thread in DBMS.

(cherry picked from commit 75a67f8febce1e7565ce0b2ce7d41cb12f5c377a)