### PR TITLE
PXC-3619: Merge PS-8.0.23 (Address Sanitizer fixes)

### DIFF
--- a/dbsim/db_client_service.hpp
+++ b/dbsim/db_client_service.hpp
@@ -55,7 +55,7 @@ namespace db
         {
             return 0;
         }
-        int remove_fragments() override { return 0; }
+        int remove_fragments(wsrep::unique_lock<wsrep::mutex>&) override { return 0; }
         int bf_rollback() override;
         void will_replay() override { }
         void wait_for_replayers(wsrep::unique_lock<wsrep::mutex>&) override { }

--- a/include/wsrep/client_service.hpp
+++ b/include/wsrep/client_service.hpp
@@ -101,9 +101,10 @@ namespace wsrep
          * Fragment removal will be committed once the current transaction
          * commits.
          *
+         * @param lock Lock object grabbed by the client_state
          * @return Zero in case of success, non-zero on failure.
          */
-        virtual int remove_fragments() = 0;
+        virtual int remove_fragments(wsrep::unique_lock<wsrep::mutex> &lock) = 0;
 
         //
         // Rollback

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -290,8 +290,10 @@ int wsrep::transaction::before_prepare(
                 ret = 1;
             }
             else
-            {
-                ret = client_service_.remove_fragments();
+            {   
+                lock.lock();
+                ret = client_service_.remove_fragments(lock);
+                lock.unlock();
                 if (ret)
                 {
                     client_state_.override_error(wsrep::e_deadlock_error);

--- a/test/mock_client_state.hpp
+++ b/test/mock_client_state.hpp
@@ -85,7 +85,7 @@ namespace wsrep
 
         void emergency_shutdown() WSREP_OVERRIDE { ++aborts_; }
 
-        int remove_fragments() WSREP_OVERRIDE
+        int remove_fragments(wsrep::unique_lock<wsrep::mutex>&) WSREP_OVERRIDE
         {
             if (bf_abort_during_fragment_removal_)
             {


### PR DESCRIPTION
Note this needs to go toghether with changes done in 8.0.23 merge https://github.com/percona/percona-xtradb-cluster/pull/1431/commits/9faf8b26f8268f9d793185e4b0350671d493f7ba

Fixed concurrent access to streaming_context::fragments vector.
This issue was discovered by galera_sr.GCF-1043B test run with Address
Sanitizer (heap-buffer-overflow in Wsrep_schema::remove_fragments()).
Problem:
We are iterating over SR fragments vector and remove them.
At the same time the SR fragments vector can be modified by wsrep
applier thread. So we need to protect it.

Details:
We cannot execute remove_fragments() under wsrep_thd_LOCK because it
acquires trx->mutex inside InnoDB (lock_table() =>lock_table_has()).
At the same time trx->mutex may be already acquired by applier thread
during BF abort of trx (row_mysql_handle_errors() => trx_kill_blocking()
=> lock_make_trx_hit_list()). So local transaction thread blocks.
Then applier thread tries to acquire wsrep_thd_LOCK (wsrep_kill_victim()
=> wsrep_innobase_kill_one_trx()), but it is already acquired by local
trx thread.

Solution:
The solution is to get the snapshot of SR fragments vector under the
lock and then process fragments removal without lock.