### PR TITLE
PXC-3265: Adding nbo_meta() getter to support NBO

### DIFF
--- a/include/wsrep/client_state.hpp
+++ b/include/wsrep/client_state.hpp
@@ -932,6 +932,11 @@ namespace wsrep
             return toi_meta_;
         }
 
+        const wsrep::ws_meta& nbo_meta() const
+        {
+            return nbo_meta_;
+        }
+
         /**
          * Do sync wait operation. If the method fails, current_error()
          * can be inspected about the reason of error.


### PR DESCRIPTION
This function is required for the server code in https://github.com/percona/percona-xtradb-cluster/pull/1481