### PR TITLE
PXC-3444: Node crashes for duplicated statements replicated as TOI

### DIFF
--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -619,6 +619,20 @@ int wsrep::transaction::before_rollback()
             state(lock, s_aborting);
         }
         break;
+    // When DML is replicated in TOI mode.
+    // This could happen while using
+    // pt-table-checksum tool which injects 99997
+    // version into the insert.. select query
+    case wsrep::client_state::m_toi:
+        if(state_ == s_executing)
+        {
+            state(lock, s_aborting);
+        }
+        else
+        {
+            assert(0);
+        }
+        break;
     default:
         assert(0);
         break;


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3444

Analysis :
Node crashes while DML is executed in TOI mode,
and getting rollback.
This behavior is specific for PXC only where DML can be replicated in TOI mode. 
This is used by pt-table-checksum tool which injects 99997 version 
into the insert.. select query.

Fix: 
Handled m_toi transaction state on rollback,
by aborting transaction while DML is executed in TOI mode.