### PR TITLE
PXC-4033: Assertion during execution of prepared statement

### DIFF
--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -237,6 +237,7 @@ int wsrep::transaction::assign_read_view(const wsrep::gtid* const gtid)
 int wsrep::transaction::append_key(const wsrep::key& key)
 {
     assert(active());
+    assert(state() == s_executing || state() == s_must_abort);
     try
     {
         debug_log_key_append(key);
@@ -253,6 +254,7 @@ int wsrep::transaction::append_key(const wsrep::key& key)
 int wsrep::transaction::append_data(const wsrep::const_buffer& data)
 {
     assert(active());
+    assert(state() == s_certifying);
     return provider().append_data(ws_handle_, data);
 }
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4033

Added assertions in wsrep transaction append_key/data to better track misusage of the transaction object.