### PR TITLE
PXC-4158: Fix compilation issues with clang

### DIFF
--- a/include/wsrep/provider_options.hpp
+++ b/include/wsrep/provider_options.hpp
@@ -69,7 +69,7 @@ namespace wsrep
                 : value_(value)
             {
             }
-            ~option_value_string() {}
+            ~option_value_string() WSREP_OVERRIDE {}
             const char* as_string() const WSREP_OVERRIDE
             {
                 return value_.c_str();
@@ -90,7 +90,7 @@ namespace wsrep
                 : value_(value)
             {
             }
-            ~option_value_bool() {}
+            ~option_value_bool() WSREP_OVERRIDE {}
             const char* as_string() const WSREP_OVERRIDE
             {
                 if (value_)
@@ -116,7 +116,7 @@ namespace wsrep
                 , value_str_(std::to_string(value))
             {
             }
-            ~option_value_int() {}
+            ~option_value_int() WSREP_OVERRIDE {}
             const char* as_string() const WSREP_OVERRIDE
             {
                 return value_str_.c_str();
@@ -136,7 +136,7 @@ namespace wsrep
                 , value_str_(std::to_string(value))
             {
             }
-            ~option_value_double() {}
+            ~option_value_double() WSREP_OVERRIDE {}
             const char* as_string() const WSREP_OVERRIDE
             {
                 return value_str_.c_str();


### PR DESCRIPTION
```
In file included from /home/vsts/work/1/s/wsrep-lib/src/provider_options.cpp:20:

/home/vsts/work/1/s/wsrep-lib/include/wsrep/provider_options.hpp:72:13: error: '~option_value_string' overrides a destructor but is not marked 'override' [-Werror,-Winconsistent-missing-destructor-override]

            ~option_value_string() {}

            ^

/home/vsts/work/1/s/wsrep-lib/include/wsrep/provider_options.hpp:60:21: note: overridden virtual function is here

            virtual ~option_value() {}
```