### PR TITLE
PXC-4228: NBO generates corrupted binlogs

### DIFF
--- a/include/wsrep/client_state.hpp
+++ b/include/wsrep/client_state.hpp
@@ -754,6 +754,14 @@ namespace wsrep
         }
 
         /**
+         * Return true if the client_state is under NBO operation.
+         */
+        bool in_nbo() const
+        {
+            return (nbo_meta_.seqno().is_undefined() == false);
+        }
+
+        /**
          * Return the mode where client entered into TOI mode.
          * The return value can be either m_local or
          * m_high_priority.

--- a/src/client_state.cpp
+++ b/src/client_state.cpp
@@ -582,9 +582,13 @@ int wsrep::client_state::begin_nbo_phase_one(
 
     int ret;
     bool timed_out;
+
+    toi_meta_ = wsrep::ws_meta();
+    nbo_meta_ = wsrep::ws_meta();
+
     auto const status(poll_enter_toi(
                           lock, keys, buffer,
-                          toi_meta_,
+                          nbo_meta_,
                           wsrep::provider::flag::start_transaction,
                           wait_until,
                           timed_out));
@@ -618,7 +622,7 @@ int wsrep::client_state::end_nbo_phase_one(const wsrep::mutable_buffer& err)
     debug_log_state("end_nbo_phase_one: enter");
     assert(state_ == s_exec);
     assert(mode_ == m_nbo);
-    assert(in_toi());
+    assert(in_nbo());
 
     enum wsrep::provider::status status(provider().leave_toi(id_, err));
     wsrep::unique_lock<wsrep::mutex> lock(mutex_);
@@ -633,8 +637,6 @@ int wsrep::client_state::end_nbo_phase_one(const wsrep::mutable_buffer& err)
         ret = 1;
         break;
     }
-    nbo_meta_ = toi_meta_;
-    toi_meta_ = wsrep::ws_meta();
     toi_mode_ = m_undefined;
     debug_log_state("end_nbo_phase_one: leave");
     return ret;


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4228

Problem
-------
Incorrect usage of toi_meta_ for DDLs running as NBO resulted in binlogging of the DDL with invalid XID.

Solution
--------
Move the initialization of toi_meta_ and nbo_meta_ to the beginning of NBO. With this, the DDLs will now use the seqno from galera to persist the XID in storage engine.

Also adjusted the assert condition in
wsrep::client_state::end_nbo_phase_one() to ensure that we are in NBO, not in TOI.