### PR TITLE
PXC-4348: Cluster state interruption with MDL BF-BF conflict and exec…

### DIFF
--- a/include/wsrep/high_priority_service.hpp
+++ b/include/wsrep/high_priority_service.hpp
@@ -235,6 +235,11 @@ namespace wsrep
          */
         virtual void debug_crash(const char* crash_point) = 0;
 
+        /**
+         * Checks if the related thread holds any MDL locks.
+        */
+        virtual bool has_mdl_locks() { return false; }
+
     protected:
         wsrep::server_state& server_state_;
         bool must_exit_;

--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -853,7 +853,7 @@ wsrep::server_state::wait_for_gtid(const wsrep::gtid& gtid, int timeout)
     return provider().wait_for_gtid(gtid, timeout);
 }
 
-int 
+int
 wsrep::server_state::set_encryption_key(std::vector<unsigned char>& key)
 {
     encryption_key_ = key;
@@ -1127,22 +1127,26 @@ int wsrep::server_state::on_apply(
     const wsrep::ws_meta& ws_meta,
     const wsrep::const_buffer& data)
 {
+    int res = -1;
+    assert(!high_priority_service.has_mdl_locks());
     if (is_toi(ws_meta.flags()))
     {
-        return apply_toi(provider(), high_priority_service,
+        res = apply_toi(provider(), high_priority_service,
                          ws_handle, ws_meta, data);
     }
     else if (is_commutative(ws_meta.flags()) || is_native(ws_meta.flags()))
     {
         // Not implemented yet.
         assert(0);
-        return 0;
+        res = 0;
     }
     else
     {
-        return apply_write_set(*this, high_priority_service,
+        res = apply_write_set(*this, high_priority_service,
                                ws_handle, ws_meta, data);
     }
+    assert(!high_priority_service.has_mdl_locks());
+    return res;
 }
 
 enum wsrep::server_state::state wsrep::server_state::state(
@@ -1408,7 +1412,7 @@ void wsrep::server_state::wait_until_state(
         cond_.wait(lock);
         // If the waiter waits for any other state than disconnecting
         // or disconnected and the state has been changed to disconnecting,
-        // this usually means that some error was encountered 
+        // this usually means that some error was encountered
         if (state != s_disconnecting && state != s_disconnected
             && state_ == s_disconnecting)
         {


### PR DESCRIPTION
…-mode:toi

https://perconadev.atlassian.net/browse/PXC-4348

Problem:
The Joiner node crashes with BF-BF abort during IST.

This wsrep-lib part of the fix contains only auxiliary functions for detection of potential problems. The main fix is in main PXC repo.