### PR TITLE
PXC-4799: PXC member used for backups fails with Inconsistency when p…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "wsrep-API/v26"]
 	path = wsrep-API/v26
-	url = https://github.com/percona/wsrep-API.git
-	branch = percona-4.x-8.0
+	url = https://github.com/jaideepkarande/wsrep-API.git
+	branch = PXC-4799-4x-80

--- a/include/wsrep/provider.hpp
+++ b/include/wsrep/provider.hpp
@@ -321,6 +321,7 @@ namespace wsrep
 
         virtual int capabilities() const = 0;
         virtual int desync() = 0;
+        virtual wsrep::seqno try_desync_and_pause() = 0;
         virtual int resync() = 0;
 
         virtual wsrep::seqno pause() = 0;

--- a/include/wsrep/server_state.hpp
+++ b/include/wsrep/server_state.hpp
@@ -500,6 +500,32 @@ namespace wsrep
         wsrep::seqno desync_and_pause();
 
         /**
+         * Try to desync and pause the provider without blocking.
+         *
+         * This call relies on provider-level try_desync_and_pause() which
+         * should return immediately with a negative value if pausing would
+         * block. On such condition this method returns undefined seqno.
+         *
+         * @return Pause seqno on success,
+         *         undefined seqno if pausing would block or fails.
+         */
+        wsrep::seqno try_desync_and_pause();
+
+        /**
+         * Wrapper of actual try_desync_and_pause with timeout.
+         * try_desync_and_pause with timeout calls try_desync_and_pause()
+         * every 100ms until success or timeout_ms elapses.
+         * When timeout_ms is 0 this method simply calls
+         * try_desync_and_pause() without waiting.
+         *
+         * @param timeout_ms  Maximum time to wait in milliseconds; 0 = try
+         *                    once.
+         * @return Pause seqno on success, undefined seqno if pausing would
+         *         block or fails.(simpl)
+         */
+        wsrep::seqno try_desync_and_pause(unsigned long timeout_ms);
+
+        /**
          * Resume and resync the provider on one go. Prior this
          * call the provider must have been both desynced and paused,
          * by either desync_and_pause() or separate calls to desync()

--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -31,6 +31,8 @@
 #include <cassert>
 #include <sstream>
 #include <algorithm>
+#include <chrono> // std::chrono*
+#include <thread> // std::this_thread::sleep_for
 
 //////////////////////////////////////////////////////////////////////////////
 //                               Helpers                                    //
@@ -634,6 +636,82 @@ wsrep::seqno wsrep::server_state::desync_and_pause()
     }
     wsrep::log_info() << "Provider paused at: " << ret;
     return ret;
+}
+
+/*
+  In try_desync_and_pause function instead of calling
+  server_state::pause/try_pause we have merged 2 functions into one and added
+  pause pre-check first followed by desynch and actual try_pause.
+  So desync_and_pause and try_desync_and_pause functions are same just that
+  in try_desync_and_pause we call try_pause instead of pause and
+  handle the case when try_pause returns state where the pausing would block.
+  In that case we roll back the desync(refer pause, resume and
+  resume_and_resync function) and return undefined seqno to indicate failure.
+  If try_pause is successful then we return the pause seqno as before.
+*/
+wsrep::seqno wsrep::server_state::try_desync_and_pause()
+{
+    wsrep::unique_lock<wsrep::mutex> lock(mutex_);
+    if (!pause_seqno_.is_undefined())
+    {
+        wsrep::log_info() << "Provider already paused at: " << pause_seqno_;
+        return pause_seqno_;
+    }
+
+    if (state(lock) != s_synced)
+    {
+        wsrep::log_info() << "Cannot pause: server not in synced state";
+        return wsrep::seqno::undefined();
+    }
+
+    while (pause_count_ > 0)
+    {
+        cond_.wait(lock);
+        if (!pause_seqno_.is_undefined()) {
+            wsrep::log_info() << "Provider already paused at: " << pause_seqno_;
+            return pause_seqno_;
+        }
+    }
+
+    wsrep::seqno result = provider().try_desync_and_pause();
+    if (result.is_undefined())
+    {
+        return wsrep::seqno::undefined();
+    }
+    ++desync_count_;
+    ++pause_count_;
+    pause_seqno_ = result;
+
+    return result;
+}
+
+wsrep::seqno wsrep::server_state::try_desync_and_pause(unsigned long timeout_ms)
+{
+    if (timeout_ms == 0)
+    {
+        return try_desync_and_pause();
+    }
+    auto const time_till_wait = std::chrono::steady_clock::now()
+                                + std::chrono::milliseconds(timeout_ms);
+    wsrep::seqno ret;
+    while (true)
+    {
+        ret = try_desync_and_pause();
+        if (!ret.is_undefined())
+        {
+            return ret;
+        }
+        /* Time has expired, undefined seqno would mean failure so return
+           undefined. */
+        if (std::chrono::steady_clock::now() >= time_till_wait)
+        {
+            wsrep::log_info() << "try_desync_and_pause timed out after "
+                              << timeout_ms << " ms";
+            return wsrep::seqno::undefined();
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    return wsrep::seqno::undefined();
 }
 
 void wsrep::server_state::resume_and_resync()

--- a/src/wsrep_provider_v26.cpp
+++ b/src/wsrep_provider_v26.cpp
@@ -975,6 +975,11 @@ wsrep::seqno wsrep::wsrep_provider_v26::pause()
     return wsrep::seqno(wsrep_->pause(wsrep_));
 }
 
+wsrep::seqno wsrep::wsrep_provider_v26::try_desync_and_pause()
+{
+    return wsrep::seqno(wsrep_->try_desync_and_pause(wsrep_));
+}
+
 int wsrep::wsrep_provider_v26::resume()
 {
     return (wsrep_->resume(wsrep_) != WSREP_OK);

--- a/src/wsrep_provider_v26.hpp
+++ b/src/wsrep_provider_v26.hpp
@@ -46,6 +46,7 @@ namespace wsrep
         int capabilities() const WSREP_OVERRIDE;
 
         int desync() WSREP_OVERRIDE;
+        wsrep::seqno try_desync_and_pause() WSREP_OVERRIDE;
         int resync() WSREP_OVERRIDE;
         wsrep::seqno pause() WSREP_OVERRIDE;
         int resume() WSREP_OVERRIDE;


### PR DESCRIPTION
…ending DDL clashes with FTRWL

Problem:
LOCK..BACKUP with FTWRL and DDL on remote node caused inconsistent state.

Description:
FTWRL caused MDL lock and waited for DDL to finish in the PXC. FTWRL specifically waits in desync_and_pause->pause statement waiting for concurrent pause statement to finish.

Resolution:
DDLs cannot be executed in parallel with FTWRL in local node it will fail. So on local node ER_CANT_UPDATE_WITH_READLOCK is seen post FTWRL FLUSH TABLES WITH READ LOCK;
--error ER_CANT_UPDATE_WITH_READLOCK
CREATE TABLE t1 (id INT PRIMARY KEY, a INT);
However in PXC remote node not aware of FTWRL on another node accepts the DDL and sends across the cluster opening a pandora of unknown conditions. So, we prevent FLUSH TABLES WITH READ LOCK when the session already holds explicit table locks.
We also check that pause will block; with ongoing TO isolation, MDL locks are likely to conflict with FTWRL, so it is best to fail FTWRL. By rejecting FLUSH TABLES WITH READ LOCK in this situation, we avoid the deadlock-like condition and allow the remote DDL to proceed to avoid situations like below:
NODE-2
LOCK INSTANCE FOR BACKUP;
NODE-1
CREATE TABLE t_synch1 (id INT PRIMARY KEY, a INT); NODE-2
FLUSH TABLES WITH READ LOCK;
NODE-2
UNLOCK TABLE;
UNLOCK INSTANCE;
NOTE: Even with this safeguard, if the DDL waiting for MDL exceeds lock_wait_timeout, the DDL will fail while waiting for the maitenance operations to finish. FLUSH or DDL will not block so the session can execute UNLOCK for the DDL to complete.
This behavior is specific to PXC. In standalone PS/PXC servers, such conflicting operations fail naturally, but in multi-node PXC deployments, DDL may arrive from another node, making this protection necessary.